### PR TITLE
Feat/brute force prevention

### DIFF
--- a/frontend/src/api/auth-api.ts
+++ b/frontend/src/api/auth-api.ts
@@ -19,6 +19,18 @@ export async function getAuthStatus(): Promise<AuthStatus> {
     .then((res) => res.data)
 }
 
+export type LoginErrorCode =
+  | 'account-is-locked'
+  | 'account-login-delay'
+  | 'wrong-credentials'
+
+export const LoginError: Record<LoginErrorCode, string> = {
+  'account-is-locked': 'Tili on lukittu. Yritä uudelleen myöhemmin.',
+  'account-login-delay':
+    'Liian monta virheellistä yritystä. Odota hetki ennen kuin yrität uudelleen.',
+  'wrong-credentials': 'Virheellinen sähköposti tai salasana'
+}
+
 export const apiPostLogin = async (emailAndPassword: {
   email: string
   password: string

--- a/frontend/src/api/users-api.ts
+++ b/frontend/src/api/users-api.ts
@@ -59,7 +59,7 @@ export type ChangePasswordErrorCode =
   | 'new-password-already-in-use'
   | 'weak-password'
 
-export const ChangePasswordError = {
+export const ChangePasswordError: Record<ChangePasswordErrorCode, string> = {
   'wrong-current-password': 'Väärä nykyinen salasana',
   'new-password-already-in-use':
     'Uusi salasana ei saa olla sama kuin nykyinen salana',

--- a/service/src/main/kotlin/fi/espoo/luontotieto/SystemController.kt
+++ b/service/src/main/kotlin/fi/espoo/luontotieto/SystemController.kt
@@ -70,7 +70,7 @@ class SystemController {
         return jdbi
             .inTransactionUnchecked {
                 // First, check if the user is locked out
-                val userIsLockedOut = it.userIsLockedOrInDelayPeriod(passwordUser.email)
+                val userIsLockedOut = it.userIsLockedOrInDelayPeriod(email = passwordUser.email)
                 if (userIsLockedOut != null) {
                     logger.info("Login attempt failed. $userIsLockedOut")
                     throw Unauthorized("Unauthorized", userIsLockedOut)

--- a/service/src/main/kotlin/fi/espoo/luontotieto/SystemController.kt
+++ b/service/src/main/kotlin/fi/espoo/luontotieto/SystemController.kt
@@ -9,7 +9,10 @@ import fi.espoo.luontotieto.common.AppUser
 import fi.espoo.luontotieto.common.Unauthorized
 import fi.espoo.luontotieto.common.getAppUser
 import fi.espoo.luontotieto.common.getAppUserWithPassword
+import fi.espoo.luontotieto.common.loginFailed
+import fi.espoo.luontotieto.common.loginSuccess
 import fi.espoo.luontotieto.common.upsertAppUserFromAd
+import fi.espoo.luontotieto.common.userIsLockedOrInDelayPeriod
 import fi.espoo.luontotieto.config.AuditEvent
 import fi.espoo.luontotieto.config.AuthenticatedUser
 import fi.espoo.luontotieto.config.audit
@@ -66,6 +69,14 @@ class SystemController {
     ): AppUser {
         return jdbi
             .inTransactionUnchecked {
+                // First, check if the user is locked out
+                val userIsLockedOut = it.userIsLockedOrInDelayPeriod(passwordUser.email)
+                if (userIsLockedOut != null) {
+                    logger.info("Login attempt failed. $userIsLockedOut")
+                    throw Unauthorized("Unauthorized", userIsLockedOut)
+                }
+
+                // Second check that the user exists, is active and the password is correct
                 val user = it.getAppUserWithPassword(passwordUser.email)
                 if (user == null) {
                     logger.info("Login attempt failed. Invalid email.")
@@ -79,9 +90,13 @@ class SystemController {
                 val encoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8()
 
                 if (!encoder.matches(passwordUser.password, user.password)) {
+                    it.loginFailed(passwordUser.email)
+                    // Make sure the login failed properties are updated even though we return error
+                    it.commit()
                     logger.info("Login attempt failed. Invalid password.")
                     throw Unauthorized()
                 }
+                it.loginSuccess(passwordUser.email)
                 user.toAppUser()
             }
             .also {

--- a/service/src/main/kotlin/fi/espoo/luontotieto/common/AppUser.kt
+++ b/service/src/main/kotlin/fi/espoo/luontotieto/common/AppUser.kt
@@ -121,7 +121,6 @@ fun Handle.userIsLockedOrInDelayPeriod(email: String): String? {
             .findOne()
             .getOrNull()
 
-
     if (userStatus != null) {
         if (userStatus.isLocked && LocalDateTime.now().isBefore(userStatus.lockoutExpiration)) {
             return "account-is-locked"

--- a/service/src/main/kotlin/fi/espoo/luontotieto/common/AppUser.kt
+++ b/service/src/main/kotlin/fi/espoo/luontotieto/common/AppUser.kt
@@ -9,10 +9,22 @@ import fi.espoo.luontotieto.domain.UserRole
 import org.jdbi.v3.core.Handle
 import org.jdbi.v3.core.kotlin.bindKotlin
 import org.jdbi.v3.core.kotlin.mapTo
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
+import kotlin.math.pow
 
 data class AdUser(val externalId: String, val name: String, val email: String?)
+
+data class UserStatus(
+    val delayUntil: LocalDateTime?,
+    val isLocked: Boolean,
+    val lockoutExpiration: LocalDateTime?
+)
+
+data class UserFailedAttempts(
+    val failedAttempts: Int,
+)
 
 data class AppUser(
     val id: UUID,
@@ -30,7 +42,7 @@ data class AppUserWithPassword(
     val password: String,
     val externalId: String?,
     val role: UserRole,
-    val active: Boolean
+    val active: Boolean,
 ) {
     fun toAppUser(): AppUser {
         return AppUser(
@@ -65,17 +77,6 @@ fun Handle.upsertAppUserFromAd(
         .mapTo<AppUser>()
         .one()
 
-fun Handle.getAppUsers(): List<AppUser> =
-    createQuery(
-        """
-    SELECT id, external_id, name, email, active
-    FROM users
-    WHERE NOT system_user
-"""
-    )
-        .mapTo<AppUser>()
-        .list()
-
 fun Handle.getAppUser(id: UUID) =
     createQuery(
         // language=SQL
@@ -105,3 +106,98 @@ fun Handle.getAppUserWithPassword(email: String) =
         .mapTo<AppUserWithPassword>()
         .findOne()
         .getOrNull()
+
+fun Handle.userIsLockedOrInDelayPeriod(email: String): String? {
+    val userStatus =
+        createQuery(
+            """
+                SELECT delay_until, is_locked, lockout_expiration 
+                FROM users 
+                WHERE email = :email
+                """
+        )
+            .bind("email", email)
+            .mapTo<UserStatus>()
+            .findOne()
+            .getOrNull()
+
+
+    if (userStatus != null) {
+        if (userStatus.isLocked && LocalDateTime.now().isBefore(userStatus.lockoutExpiration)) {
+            return "account-is-locked"
+        } else if (userStatus.delayUntil != null && LocalDateTime.now().isBefore(userStatus.delayUntil)) {
+            return "account-login-delay"
+        }
+    }
+
+    return null
+}
+
+/**
+ * Record a failed login attempt and set progressive delay or lock account if necessary
+ * Example workflow lopgic
+ * First 2 failed attempts: No delay.
+ * 3rd failed attempt: 5 seconds delay.
+ * 4th failed attempt: 10 seconds delay.
+ * 5th failed attempt: 20 seconds delay, and lockout if the threshold is reached.
+ */
+fun Handle.loginFailed(email: String) {
+    //  1. Fetch the current number of failed attempts from the database
+    val currentFailedAttempts =
+        createQuery(
+            """
+                SELECT failed_attempts 
+                FROM users 
+                WHERE email = :email
+                """
+        )
+            .bind("email", email)
+            .mapTo<UserFailedAttempts>()
+            .one()
+
+    val baseDelay = 5
+    // 2. Calculate the exponential delay
+    // - If the number of failedAttempts is less than 2, the delay is the base delay
+    // - If the number of failed attempts is greater than or equal to 2, the delay increases exponentially
+    val delayTime = baseDelay * 2.0.pow(maxOf(0, currentFailedAttempts.failedAttempts - 2).toDouble()).toInt()
+
+    // 3. Update the user's failed attempts, delay_until, and lock the account if necessary
+    createUpdate(
+        """
+     UPDATE users 
+        SET 
+            failed_attempts = failed_attempts + 1,
+            last_failed_attempt = NOW(),
+            delay_until = CASE 
+                WHEN failed_attempts >= 2 THEN NOW() + INTERVAL '1 second' * :delayTime
+                ELSE delay_until 
+            END,
+            is_locked = CASE 
+                WHEN failed_attempts + 1 >= 5 THEN TRUE 
+                ELSE is_locked 
+            END,
+            lockout_expiration = CASE 
+                WHEN failed_attempts + 1 >= 5 THEN NOW() + INTERVAL '5 minutes'
+                ELSE lockout_expiration 
+            END
+        WHERE email = :email
+    """
+    )
+        .bind("email", email)
+        .bind("delayTime", delayTime)
+        .execute()
+}
+
+fun Handle.loginSuccess(email: String) =
+    createUpdate(
+        """
+            UPDATE users SET 
+            failed_attempts = 0, 
+            is_locked = FALSE, 
+            delay_until = NULL, 
+            lockout_expiration = NULL
+            WHERE email = :email
+            """
+    )
+        .bind("email", email)
+        .execute()

--- a/service/src/main/kotlin/fi/espoo/luontotieto/common/AppUser.kt
+++ b/service/src/main/kotlin/fi/espoo/luontotieto/common/AppUser.kt
@@ -134,11 +134,11 @@ fun Handle.userIsLockedOrInDelayPeriod(email: String): String? {
 
 /**
  * Record a failed login attempt and set progressive delay or lock account if necessary
- * Example workflow lopgic
+ * Example workflow logic
  * First 2 failed attempts: No delay.
  * 3rd failed attempt: 5 seconds delay.
  * 4th failed attempt: 10 seconds delay.
- * 5th failed attempt: 20 seconds delay, and lockout if the threshold is reached.
+ * 5th failed attempt: 20 seconds delay, and a 5 minutes lockout if the threshold is reached.
  */
 fun Handle.loginFailed(email: String) {
     //  1. Fetch the current number of failed attempts from the database

--- a/service/src/main/resources/db/luontotieto/migration/V0022__update_user_table_with_lockout.sql
+++ b/service/src/main/resources/db/luontotieto/migration/V0022__update_user_table_with_lockout.sql
@@ -1,0 +1,14 @@
+ALTER TABLE users
+    ADD COLUMN failed_attempts INT DEFAULT 0;
+
+ALTER TABLE users
+    ADD COLUMN is_locked BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE users
+    ADD COLUMN lockout_expiration TIMESTAMP NULL;
+
+ALTER TABLE users
+    ADD COLUMN last_failed_attempt TIMESTAMP NULL;
+
+ALTER TABLE users
+    ADD COLUMN delay_until TIMESTAMP NULL


### PR DESCRIPTION
- Add brute force protection by a progressively increasing login delay
Works as the below example: 

```
 * First 2 failed attempts: No delay.
 * 3rd failed attempt: 5 seconds delay.
 * 4th failed attempt: 10 seconds delay.
 * 5th failed attempt: 20 seconds delay, and a 5 minutes lockout if the threshold is reached.
```
