### PR TITLE
Update the order data handling

### DIFF
--- a/frontend/src/api/order-api.ts
+++ b/frontend/src/api/order-api.ts
@@ -15,6 +15,7 @@ export interface Order extends OrderFormInput {
   assignee: string
   createdBy: string
   updatedBy: string
+  hasApprovedReport: boolean
 }
 
 export interface OrderFormInput {
@@ -218,11 +219,15 @@ export const apiGetPlanNumbers = (): Promise<string[]> =>
 export const apiGetorderingUnits = (): Promise<string[]> =>
   apiClient.get<string[]>(`/orders/ordering-units`).then((res) => res.data)
 
-export type DeleteorderErrorCode = 'order-delete-failed-existing-files'
+export type DeleteorderErrorCode =
+  | 'order-delete-failed-existing-files'
+  | 'order-delete-failed-report-approved'
 
-export const DeleteOrderError = {
+export const DeleteOrderError: Record<DeleteorderErrorCode, string> = {
   'order-delete-failed-existing-files':
-    'Tilaukseen on jo lisätty tiedostoja joten tilausta ei voitu poistaa.'
+    'Tilaukseen on jo lisätty tiedostoja joten tilausta ei voitu poistaa.',
+  'order-delete-failed-report-approved':
+    'Tilauksen selvitys on jo hyväksytty joten tilausta ei voi poistaa'
 }
 export const apiDeleteOrder = (id: string): Promise<void> =>
   apiClient.delete<void>(`/orders/${id}`).then((res) => res.data)

--- a/frontend/src/luontotieto/order/OrderForm.tsx
+++ b/frontend/src/luontotieto/order/OrderForm.tsx
@@ -44,6 +44,7 @@ interface CreateProps {
   planNumbers: string[]
   orderingUnits: string[]
   errors: OrderFileValidationErrorResponse[]
+  disabled?: boolean
 }
 
 interface EditProps {
@@ -54,6 +55,7 @@ interface EditProps {
   planNumbers: string[]
   orderingUnits: string[]
   errors: OrderFileValidationErrorResponse[]
+  disabled?: boolean
 }
 
 type Props = CreateProps | EditProps
@@ -436,6 +438,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
               <TextArea
                 onChange={(name) => setOrderInput({ ...orderInput, name })}
                 value={orderInput.name}
+                readonly={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -452,6 +455,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                 }
                 onChange={updateOrderingUnits}
                 placeholderText="Etsi tai lisää yksikkö"
+                disabled={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -468,6 +472,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                 }
                 onChange={updatePlanNumbers}
                 placeholderText="Etsi tai lisää kaava"
+                disabled={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -481,6 +486,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                 }
                 value={orderInput.returnDate}
                 type="date"
+                readonly={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -496,6 +502,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                 }
                 value={orderInput.description}
                 rows={2}
+                readonly={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -511,6 +518,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                   })
                 }
                 value={orderInput.contactPerson}
+                readonly={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -526,6 +534,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                 }
                 value={orderInput.contactEmail}
                 info={invalidContactEmailInfo}
+                readonly={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -540,6 +549,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                   })
                 }
                 value={orderInput.contactPhone}
+                readonly={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -558,6 +568,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                 }
                 getItemLabel={(u) => u?.name ?? '-'}
                 getItemValue={(u) => u?.id ?? '-'}
+                disabled={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -572,6 +583,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                   })
                 }
                 value={orderInput.assigneeContactPerson}
+                readonly={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -587,6 +599,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                 }
                 value={orderInput.assigneeContactEmail}
                 info={invalidAssigneeContactEmailInfo}
+                readonly={props.disabled}
               />
             </LabeledInput>
           </RowOfInputs>
@@ -612,6 +625,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
               }
               accept=".gpkg"
               required={true}
+              readOnly={props.disabled}
             />
           )}
           {orderAreaFile && orderAreaFile.type === 'EXISTING' && (
@@ -620,7 +634,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
               data={{
                 type: 'ORDER',
                 file: orderAreaFile.orderFile,
-                readonly: false,
+                readonly: props.disabled ?? false,
                 documentType: orderAreaFile.documentType,
                 updated: orderAreaFile.orderFile.updated
               }}
@@ -651,6 +665,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                       props.errors.find((error) => error.id === fInput.id)
                         ?.errors
                     }
+                    readOnly={props.disabled}
                   />
                 )
               case 'EXISTING':
@@ -661,7 +676,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                     data={{
                       type: 'ORDER',
                       file: fInput.orderFile,
-                      readonly: false,
+                      readonly: props.disabled ?? false,
                       documentType: fInput.documentType,
                       updated: fInput.orderFile.updated
                     }}
@@ -689,6 +704,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
               }
             ])
           }
+          disabled={props.disabled}
         />
       </SectionContainer>
       <VerticalGap $size="m" />
@@ -710,6 +726,7 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                       documentType: rd.documentType
                     })
                   }
+                  disabled={props.disabled}
                 />
               ))}
             </LabeledInput>

--- a/frontend/src/luontotieto/order/OrderFormPage.tsx
+++ b/frontend/src/luontotieto/order/OrderFormPage.tsx
@@ -224,6 +224,7 @@ export const OrderFormPage = React.memo(function OrderFormPage(props: Props) {
             planNumbers={planNumbers ?? []}
             orderingUnits={orderingUnits ?? []}
             errors={orderFileErrors}
+            disabled={order?.hasApprovedReport}
           />
         )}
 
@@ -237,6 +238,7 @@ export const OrderFormPage = React.memo(function OrderFormPage(props: Props) {
             planNumbers={planNumbers ?? []}
             orderingUnits={orderingUnits ?? []}
             errors={orderFileErrors}
+            disabled={order?.hasApprovedReport}
           />
         )}
       </PageContainer>
@@ -249,7 +251,7 @@ export const OrderFormPage = React.memo(function OrderFormPage(props: Props) {
                 text="Poista selvitystilaus"
                 className="danger"
                 data-qa="save-button"
-                disabled={deletingOrder}
+                disabled={deletingOrder || order?.hasApprovedReport}
                 onClick={() => {
                   if (order) {
                     setShowModal({
@@ -278,7 +280,12 @@ export const OrderFormPage = React.memo(function OrderFormPage(props: Props) {
               text="Tallenna"
               data-qa="save-button"
               primary
-              disabled={!orderInput || savingOrder || updatingOrder}
+              disabled={
+                !orderInput ||
+                savingOrder ||
+                updatingOrder ||
+                order?.hasApprovedReport
+              }
               onClick={async () => {
                 if (!orderInput) return
 

--- a/frontend/src/shared/form/TagAutoComplete/TagAutoComplete.tsx
+++ b/frontend/src/shared/form/TagAutoComplete/TagAutoComplete.tsx
@@ -171,13 +171,15 @@ interface Props {
   data: Tag[]
   onChange: (selected: Tag[]) => void
   placeholderText: string
+  disabled?: boolean
 }
 
 export const TagAutoComplete = ({
   onChange,
   suggestions,
   data,
-  placeholderText
+  placeholderText,
+  disabled
 }: Props) => {
   const [selected, setSelected] = useState<Tag[]>(data ?? [])
 
@@ -210,6 +212,7 @@ export const TagAutoComplete = ({
         onAdd={onAdd}
         onDelete={onDelete}
         noOptionsText="Ei hakutuloksia"
+        isDisabled={disabled}
       />
     </Wrapper>
   )

--- a/service/src/main/kotlin/fi/espoo/luontotieto/domain/Report.kt
+++ b/service/src/main/kotlin/fi/espoo/luontotieto/domain/Report.kt
@@ -64,7 +64,8 @@ private const val SELECT_REPORT_SQL =
            o.contact_person                           AS "o_contactPerson",
            o.contact_phone                            AS "o_contactPhone",
            o.contact_email                            AS "o_contactEmail",
-           o.ordering_unit                            AS "o_orderingUnit"
+           o.ordering_unit                            AS "o_orderingUnit",
+           r.approved                                 AS "o_hasApprovedReport"
     FROM report r
              LEFT JOIN users uc ON r.created_by = uc.id
              LEFT JOIN users uu ON r.updated_by = uu.id

--- a/service/src/main/kotlin/fi/espoo/luontotieto/domain/ReportController.kt
+++ b/service/src/main/kotlin/fi/espoo/luontotieto/domain/ReportController.kt
@@ -342,7 +342,12 @@ class ReportController {
             throw BadRequest("Cannot reopen a report that has not been approved.")
         }
         paikkatietoJdbi.inTransactionUnchecked { ptx ->
-            TableDefinition.entries.forEach { td -> ptx.deletePaikkatieto(td, report.id) }
+            /**
+             * Delete all paikkatieto data for the report except for the aluerajaus_luontoselvitystilaus
+             * table. The order data is updated only when order is modified.
+             */
+            TableDefinition.entries.filter { td -> td.layerName !== "aluerajaus_luontoselvitystilaus" }
+                .forEach { td -> ptx.deletePaikkatieto(td, report.id) }
         }
 
         jdbi

--- a/service/src/main/resources/db/paikkatieto/migration/V019__update_aluerajaus_luontoselvitystilaus_tilaus_vuosi.sql
+++ b/service/src/main/resources/db/paikkatieto/migration/V019__update_aluerajaus_luontoselvitystilaus_tilaus_vuosi.sql
@@ -1,0 +1,2 @@
+ALTER TABLE aluerajaus_luontoselvitystilaus
+ALTER COLUMN tilaus_vuosi SET DEFAULT EXTRACT(YEAR FROM CURRENT_DATE)::INTEGER;


### PR DESCRIPTION
Fixes following bugs:
 - Data was incorrectly deleted from `aluerajaus_luontoselvitystilaus` when report was reopened
 - Details in `aluerajaus_luontoselvitystilaus` were not correctly updated when updating report
 - Report name was not correctly updated when updating report
 - Generate default value for `aluerajaus_luontoselvitystilaus.tilaus_vuosi`
 
Added guard rails:
- Do not allow updating order when it has approved report
- Do not allow deleting order when it has approved report
- Do not allow deleting order file when it has approved report
- Do not allow adding order file when it has approved report
