### PR TITLE
Feat/improve file upload error handlings

### DIFF
--- a/frontend/src/api/order-api.ts
+++ b/frontend/src/api/order-api.ts
@@ -191,6 +191,7 @@ const apiPostOrderFile = async (
 ): Promise<OrderFileSuccessResponse | OrderFileValidationErrorResponse> => {
   const formData = new FormData()
   formData.append('file', file.file)
+  formData.append('id', file.id)
   formData.append('description', file.description)
   formData.append('documentType', OrderFileDocumentType[file.documentType])
 

--- a/frontend/src/api/report-api.ts
+++ b/frontend/src/api/report-api.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { apiClient } from 'api-client'
-import { AxiosHeaders, AxiosResponse } from 'axios'
+import { AxiosError, AxiosHeaders, AxiosResponse } from 'axios'
 import FileSaver from 'file-saver'
 import { JsonOf } from 'shared/api-utils'
 
@@ -99,6 +99,7 @@ export interface ReportDetails {
 }
 
 export interface ReportFileInput {
+  id: string
   description: string
   documentType: ReportFileDocumentType
   file: File
@@ -106,7 +107,6 @@ export interface ReportFileInput {
 }
 
 export interface ReportFileDetails extends ReportFileInput {
-  id: string
   mediaType: string
   fileName: string
   created: Date
@@ -118,7 +118,10 @@ export interface ReportFileDetails extends ReportFileInput {
 
 export const apiPutReport = async (
   reportInput: { reportId: string } & ReportFormInput
-): Promise<ReportDetails> => {
+): Promise<
+  | ReportDetails
+  | (ReportFileSuccessResponse | ReportFileValidationErrorResponse)[]
+> => {
   const body: JsonOf<ReportFormInput> = {
     ...reportInput
   }
@@ -131,9 +134,19 @@ export const apiPutReport = async (
     await apiClient.delete(`/reports/${report.id}/files/${id}`)
   }
 
-  for (const file of reportInput.filesToAdd) {
-    await apiPostReportFile(report.id, file)
+  /** Make sure we try to save all files so the saving does not stop with the first file with error */
+  const postPromises = reportInput.filesToAdd.map((f) =>
+    apiPostReportFile(report.id, f)
+  )
+  const responses = await Promise.all(postPromises)
+
+  if (responses.find((r) => 'errors' in r)) {
+    /** Return all file responses to make sure we have a list of the saved files also */
+    return Promise.reject(responses)
   }
+  // for (const file of reportInput.filesToAdd) {
+  //   await apiPostReportFile(report.id, file)
+  // }
 
   return report
 }
@@ -173,30 +186,72 @@ export interface ReportFileValidationError {
   reason: string
 }
 
-export interface ReportFileValidationErrorResponse {
+export type ReportFileSuccessResponse = {
+  type: 'success'
+}
+
+export type ReportFileValidationErrorResponse = {
+  type: 'error'
   documentType: ReportFileDocumentType
-  errors: ReportFileValidationError[]
+  errors: ReportFileValidationError[] | string
+  name: string
+  id: string
 }
 
 const apiPostReportFile = async (
   id: string,
   file: ReportFileInput
-): Promise<void> => {
+): Promise<ReportFileSuccessResponse | ReportFileValidationErrorResponse> => {
   const formData = new FormData()
   formData.append('file', file.file)
   formData.append('description', file.description)
   formData.append('documentType', ReportFileDocumentType[file.documentType])
 
-  await apiClient
+  return await apiClient
     .postForm(`/reports/${id}/files`, formData)
-    .catch((error: { response: { data: ReportFileValidationError } }) => {
-      const errorResponse = {
-        documentType: file.documentType,
-        errors: error.response.data
+    .then(
+      (_resp) =>
+        ({
+          type: 'success'
+        }) satisfies ReportFileSuccessResponse
+    )
+    .catch((error: AxiosError) => {
+      if (error.response?.status === 400) {
+        const errorResponse = {
+          type: 'error',
+          documentType: file.documentType,
+          id: file.id,
+          name: file.file.name,
+          errors: error?.response?.data
+        } as ReportFileValidationErrorResponse
+        return errorResponse
+      } else if (error.response?.status === 409) {
+        const errorResponse = {
+          type: 'error',
+          documentType: file.documentType,
+          id: file.id,
+          name: file.file.name,
+          errors: 'Tiedostonimi on jo olemassa'
+        } as ReportFileValidationErrorResponse
+        return errorResponse
+      } else if (error.response?.status === 413) {
+        const errorResponse = {
+          type: 'error',
+          documentType: file.documentType,
+          id: file.id,
+          name: file.file.name,
+          errors: 'Tiedosto on liian suuri. Sallittu maksimikoko on 100 Mt.'
+        } as ReportFileValidationErrorResponse
+        return errorResponse
       }
-      return Promise.reject(errorResponse)
+      return {
+        type: 'error',
+        documentType: file.documentType,
+        id: file.id,
+        name: file.file.name,
+        errors: 'Tuntematon virhe'
+      } as ReportFileValidationErrorResponse
     })
-  return Promise.resolve()
 }
 
 export const apiGetReport = (id: string): Promise<ReportDetails> =>

--- a/frontend/src/api/report-api.ts
+++ b/frontend/src/api/report-api.ts
@@ -204,6 +204,7 @@ const apiPostReportFile = async (
 ): Promise<ReportFileSuccessResponse | ReportFileValidationErrorResponse> => {
   const formData = new FormData()
   formData.append('file', file.file)
+  formData.append('id', file.id)
   formData.append('description', file.description)
   formData.append('documentType', ReportFileDocumentType[file.documentType])
 

--- a/frontend/src/luontotieto/order/OrderForm.tsx
+++ b/frontend/src/luontotieto/order/OrderForm.tsx
@@ -360,7 +360,6 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
     if (!orderInput.contactEmail.trim().match(emailRegex)) return null
     if (orderInput.assigneeContactPerson.trim() === '') return null
     if (!orderInput.assigneeContactEmail.trim().match(emailRegex)) return null
-
     return {
       name: orderInput.name.trim(),
       description: orderInput.description.trim(),
@@ -384,7 +383,8 @@ export const OrderForm = React.memo(function OrderForm(props: Props) {
                 description: e.description,
                 documentType: e.documentType,
                 file: e.file,
-                id: e.id
+                id: e.id,
+                name: e.file.name
               }
             ]
           : []

--- a/frontend/src/luontotieto/order/OrderForm.tsx
+++ b/frontend/src/luontotieto/order/OrderForm.tsx
@@ -106,13 +106,6 @@ function createFileInputs(
         (i) => documentType === i.documentType
       )
       if (existingFile) {
-        if (
-          existingInMemoryFile &&
-          existingInMemoryFile.type === 'NEW' &&
-          existingInMemoryFile.id !== existingFile.id
-        ) {
-          return existingInMemoryFile
-        }
         return {
           documentType,
           type: 'EXISTING',

--- a/frontend/src/luontotieto/order/OrderFormPage.tsx
+++ b/frontend/src/luontotieto/order/OrderFormPage.tsx
@@ -95,13 +95,15 @@ export const OrderFormPage = React.memo(function OrderFormPage(props: Props) {
     reloadOrder = true
   ) => {
     if (reloadOrder) {
-      void queryClient.invalidateQueries({ queryKey: ['order', orderId ?? id] })
+      await queryClient.invalidateQueries({
+        queryKey: ['order', orderId ?? id]
+      })
     }
-    void queryClient.invalidateQueries({
+    await queryClient.invalidateQueries({
       queryKey: ['orderFiles', orderId ?? id]
     })
-    void queryClient.invalidateQueries({ queryKey: ['plan-numbers'] })
-    void queryClient.invalidateQueries({ queryKey: ['ordering-units'] })
+    await queryClient.invalidateQueries({ queryKey: ['plan-numbers'] })
+    await queryClient.invalidateQueries({ queryKey: ['ordering-units'] })
   }
   const resetFormState = async (orderId: string | undefined) => {
     setOrderFileErrors([])
@@ -118,7 +120,6 @@ export const OrderFormPage = React.memo(function OrderFormPage(props: Props) {
           title: 'Tilaus luotu',
           resolve: {
             action: () => {
-              resetFormState(orderId)
               setShowModal(null)
               navigate(`/luontotieto/selvitys/${reportId}`)
             },
@@ -173,8 +174,8 @@ export const OrderFormPage = React.memo(function OrderFormPage(props: Props) {
   const { mutateAsync: updateOrderMutation, isPending: updatingOrder } =
     useMutation({
       mutationFn: apiPutOrder,
-      onSuccess: (_order): void => {
-        resetFormState(orderId)
+      onSuccess: async (_order) => {
+        await resetFormState(orderId)
         setShowModal({
           title: 'Tilaus päivitetty',
           resolve: {
@@ -220,8 +221,8 @@ export const OrderFormPage = React.memo(function OrderFormPage(props: Props) {
   const { mutateAsync: deleteOrderMutation, isPending: deletingOrder } =
     useMutation({
       mutationFn: apiDeleteOrder,
-      onSuccess: (_order): void => {
-        resetFormState(orderId)
+      onSuccess: async (_order) => {
+        await resetFormState(orderId)
         setShowModal({
           title: 'Tilaus poistettu',
           resolve: {

--- a/frontend/src/luontotieto/report/OrderDetails.tsx
+++ b/frontend/src/luontotieto/report/OrderDetails.tsx
@@ -9,6 +9,7 @@ import { getDocumentTypeTitle } from 'api/report-api'
 import { hasOrdererRole, UserContext } from 'auth/UserContext'
 import React, { useContext, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { IconButton } from 'shared/buttons/IconButton'
 import { LinkFileDownload } from 'shared/buttons/LinkFileDownload'
 import { formatDate, parseDate } from 'shared/dates'
 import styled from 'styled-components'
@@ -20,7 +21,6 @@ import {
   VerticalGap
 } from '../../shared/layout'
 import { H3, Label, P } from '../../shared/typography'
-import { IconButton } from 'shared/buttons/IconButton'
 
 type Props = { order: Order; reportId: string }
 

--- a/frontend/src/luontotieto/report/ReportApproval.tsx
+++ b/frontend/src/luontotieto/report/ReportApproval.tsx
@@ -5,8 +5,10 @@
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ReportDetails } from 'api/report-api'
+import { UserRole } from 'api/users-api'
 import { UserContext, hasOrdererRole } from 'auth/UserContext'
 import React, { useContext, useMemo, useState } from 'react'
+import { InfoBox } from 'shared/MessageBoxes'
 import { formatDateTime } from 'shared/dates'
 import { Checkbox } from 'shared/form/Checkbox'
 import { colors } from 'shared/theme'
@@ -18,8 +20,6 @@ import {
   VerticalGap
 } from '../../shared/layout'
 import { B, H3, P } from '../../shared/typography'
-import { UserRole } from 'api/users-api'
-import { InfoBox } from 'shared/MessageBoxes'
 
 type Props = {
   report: ReportDetails

--- a/frontend/src/luontotieto/report/ReportForm.tsx
+++ b/frontend/src/luontotieto/report/ReportForm.tsx
@@ -18,9 +18,12 @@ import {
   ReportFormInput
 } from 'api/report-api'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { InfoBox } from 'shared/MessageBoxes'
 import { InlineButton } from 'shared/buttons/InlineButton'
+import { Checkbox } from 'shared/form/Checkbox'
 import { ExistingFile } from 'shared/form/File/ExistingFile'
 import { FileInput, FileInputData } from 'shared/form/File/FileInput'
+import { colors } from 'shared/theme'
 import { useDebouncedState } from 'shared/useDebouncedState'
 import styled from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
@@ -33,9 +36,6 @@ import {
   VerticalGap
 } from '../../shared/layout'
 import { A, H3, Label, P } from '../../shared/typography'
-import { Checkbox } from 'shared/form/Checkbox'
-import { InfoBox } from 'shared/MessageBoxes'
-import { colors } from 'shared/theme'
 
 const StyledInlineButton = styled(InlineButton)`
   font-size: 0.9rem;
@@ -504,20 +504,20 @@ export const ReportFileIsPublic = React.memo(function ReportFileIsPublic({
         )}
         <FlexRow>
           <Checkbox
-            key={'yes'}
-            label={'Kyllä'}
+            key="yes"
+            label="Kyllä"
             checked={!!localPublic}
-            onChange={(checked) => {
+            onChange={(_checked) => {
               setLocalPublic(true)
               onChange(true)
             }}
             disabled={readOnly}
           />
           <StyledCheckBox
-            key={'no'}
-            label={'Ei'}
+            key="no"
+            label="Ei"
             checked={localPublic === false}
-            onChange={(checked) => {
+            onChange={(_checked) => {
               setLocalPublic(false)
               onChange(false)
             }}

--- a/frontend/src/luontotieto/report/ReportForm.tsx
+++ b/frontend/src/luontotieto/report/ReportForm.tsx
@@ -234,7 +234,7 @@ export const ReportForm = React.memo(function ReportForm(
         requiredFiles,
         noObservations ?? []
       ),
-    [requiredFiles, props, noObservations]
+    [requiredFiles, props.reportFiles, noObservations]
   )
 
   const [name, _] = useDebouncedState(props.report.name)
@@ -330,6 +330,7 @@ export const ReportForm = React.memo(function ReportForm(
         e.type === 'NEW' && e.file !== null
           ? [
               {
+                id: e.id,
                 description: e.userDescription,
                 documentType: e.documentType,
                 file: e.file
@@ -344,6 +345,10 @@ export const ReportForm = React.memo(function ReportForm(
   useEffect(() => {
     props.onChange(validInput)
   }, [validInput, props])
+
+  useEffect(() => {
+    setFileInputs(originalFileInputs)
+  }, [originalFileInputs])
 
   return (
     <FlexCol>

--- a/frontend/src/luontotieto/report/ReportFormPage.tsx
+++ b/frontend/src/luontotieto/report/ReportFormPage.tsx
@@ -141,11 +141,8 @@ export const ReportFormPage = React.memo(function ReportFormPage() {
       })
     }
   })
-  console.log()
 
   const onSubmit = async (reportInput: ReportFormInput) => {
-    console.log('ON SUBMIT RENDER???')
-    console.log(overrideReportName)
     if (report && report.approved && reOpen) {
       setShowModal({
         title: 'Avaa selvitys uudelleen',

--- a/frontend/src/luontotieto/report/ReportFormPage.tsx
+++ b/frontend/src/luontotieto/report/ReportFormPage.tsx
@@ -82,8 +82,8 @@ export const ReportFormPage = React.memo(function ReportFormPage() {
           title: 'Tiedot tallennettu',
           resolve: {
             action: async () => {
-              void queryClient.invalidateQueries({ queryKey: ['report', id] })
-              void queryClient.invalidateQueries({
+              await queryClient.invalidateQueries({ queryKey: ['report', id] })
+              await queryClient.invalidateQueries({
                 queryKey: ['reportFiles', id]
               })
               closeModal()

--- a/frontend/src/luontotieto/report/ReportList.tsx
+++ b/frontend/src/luontotieto/report/ReportList.tsx
@@ -22,6 +22,7 @@ import { Select } from 'shared/form/Select'
 import InfoModal, { InfoModalStateProps } from 'shared/modals/InfoModal'
 import { Label, P } from 'shared/typography'
 import { useDebouncedState } from 'shared/useDebouncedState'
+import styled from 'styled-components'
 
 import { hasOrdererRole, UserContext } from '../../auth/UserContext'
 import {
@@ -34,7 +35,6 @@ import {
   Table,
   VerticalGap
 } from '../../shared/layout'
-import styled from 'styled-components'
 
 export type ReportSortColumn = 'updated' | 'name' | 'approved'
 export type SortDirection = 'ASC' | 'DESC'

--- a/frontend/src/shared/buttons/LinkFileDownload.tsx
+++ b/frontend/src/shared/buttons/LinkFileDownload.tsx
@@ -5,6 +5,7 @@
 import React from 'react'
 
 import { BaseProps } from '../theme'
+
 import { StyledLink } from './StyledLink'
 
 export interface LinkFileDownloadProps extends BaseProps {

--- a/frontend/src/shared/form/File/FileTitle.tsx
+++ b/frontend/src/shared/form/File/FileTitle.tsx
@@ -34,7 +34,7 @@ export const Link = styled(StyledLink)`
 export const FileTitle = React.memo(function FileTitle(props: Props) {
   return (
     <Label>
-      {`${getDocumentTypeTitle(props.documentType)} ${props.required && '*'}`}
+      {`${getDocumentTypeTitle(props.documentType)} ${props.required ? '*' : ''}`}
       {isReportFileDocumentType(props.documentType) &&
         props.documentType !== ReportFileDocumentType.OTHER &&
         props.documentType !== ReportFileDocumentType.REPORT && (

--- a/frontend/src/shared/form/File/FileTitle.tsx
+++ b/frontend/src/shared/form/File/FileTitle.tsx
@@ -46,7 +46,7 @@ export const FileTitle = React.memo(function FileTitle(props: Props) {
             }
             onKeyDown={(event: React.KeyboardEvent<HTMLAnchorElement>) => {
               if (event.code === 'Enter') {
-                apiGetReportDocumentTypeFileTemplate(
+                void apiGetReportDocumentTypeFileTemplate(
                   props.documentType as ReportFileDocumentType
                 )
               }

--- a/service/src/main/kotlin/fi/espoo/luontotieto/domain/OrderFile.kt
+++ b/service/src/main/kotlin/fi/espoo/luontotieto/domain/OrderFile.kt
@@ -38,6 +38,7 @@ data class OrderFile(
 )
 
 data class OrderFileInput(
+    val fileId: UUID,
     val orderId: UUID,
     val description: String?,
     val mediaType: String,
@@ -51,11 +52,12 @@ fun Handle.insertOrderFile(
 ): UUID {
     return createUpdate(
         """
-            INSERT INTO order_file (order_id, description, media_type, file_name, document_type, created_by, updated_by) 
-            VALUES (:orderId, :description, :mediaType, :fileName, :documentType, :createdBy, :updatedBy)
+            INSERT INTO order_file (id,order_id, description, media_type, file_name, document_type, created_by, updated_by) 
+            VALUES (:id, :orderId, :description, :mediaType, :fileName, :documentType, :createdBy, :updatedBy)
             RETURNING id
             """
     )
+        .bind("id", data.fileId)
         .bind("orderId", data.orderId)
         .bind("description", data.description)
         .bind("mediaType", data.mediaType)

--- a/service/src/main/kotlin/fi/espoo/luontotieto/domain/ReportFile.kt
+++ b/service/src/main/kotlin/fi/espoo/luontotieto/domain/ReportFile.kt
@@ -133,6 +133,7 @@ data class ReportFile(
 )
 
 data class ReportFileInput(
+    val fileId: UUID,
     val reportId: UUID,
     val description: String?,
     val mediaType: String,
@@ -146,11 +147,12 @@ fun Handle.insertReportFile(
 ): UUID {
     return createUpdate(
         """
-            INSERT INTO report_file (report_id, description, media_type, file_name, document_type, created_by, updated_by) 
-            VALUES (:reportId, :description, :mediaType, :fileName, :documentType, :createdBy, :updatedBy)
+            INSERT INTO report_file (id, report_id, description, media_type, file_name, document_type, created_by, updated_by) 
+            VALUES (:id, :reportId, :description, :mediaType, :fileName, :documentType, :createdBy, :updatedBy)
             RETURNING id
             """
     )
+        .bind("id", data.fileId)
         .bind("reportId", data.reportId)
         .bind("description", data.description)
         .bind("mediaType", data.mediaType)

--- a/service/src/test/kotlin/fi/espoo/luontotieto/OrderFileTests.kt
+++ b/service/src/test/kotlin/fi/espoo/luontotieto/OrderFileTests.kt
@@ -8,12 +8,14 @@ import fi.espoo.luontotieto.domain.OrderController
 import fi.espoo.luontotieto.domain.OrderDocumentType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.mock.web.MockMultipartFile
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class OrderFileTests : FullApplicationTest() {
-    @Autowired lateinit var controller: OrderController
+    @Autowired
+    lateinit var controller: OrderController
 
     @Test
     fun `create order files and fetch and delete`() {
@@ -27,10 +29,11 @@ class OrderFileTests : FullApplicationTest() {
                     "tilaus_ohje.txt",
                     "tilaus_ohje.txt",
                     "text/plain",
-                    "ORDER INFO CONTENT".toByteArray()
+                    "ORDER INFO CONTENT".toByteArray(),
                 ),
             documentType = OrderDocumentType.ORDER_INFO,
-            description = "Test Description"
+            description = "Test Description",
+            id = UUID.randomUUID().toString()
         )
 
         val orderFileResponse = controller.getOrderFiles(adminUser, createdOrder.orderId)

--- a/service/src/test/kotlin/fi/espoo/luontotieto/OrderTests.kt
+++ b/service/src/test/kotlin/fi/espoo/luontotieto/OrderTests.kt
@@ -164,7 +164,8 @@ class OrderTests : FullApplicationTest() {
                     "ORDER INFO CONTENT".toByteArray()
                 ),
             documentType = OrderDocumentType.ORDER_INFO,
-            description = "Test Description"
+            description = "Test Description",
+            id = UUID.randomUUID().toString()
         )
 
         createLiitoOravaPisteetReportFile(reportController, createdOrder.reportId)
@@ -211,7 +212,8 @@ class OrderTests : FullApplicationTest() {
                         "ORDER INFO CONTENT".toByteArray()
                     ),
                 documentType = OrderDocumentType.ORDER_INFO,
-                description = "Test Description"
+                description = "Test Description",
+                id = UUID.randomUUID().toString()
             )
         }
         val orderFileResponse = controller.getOrderFiles(adminUser, createdOrder.orderId)

--- a/service/src/test/kotlin/fi/espoo/luontotieto/ReportFileTests.kt
+++ b/service/src/test/kotlin/fi/espoo/luontotieto/ReportFileTests.kt
@@ -13,15 +13,18 @@ import org.springframework.mock.web.MockMultipartFile
 import org.springframework.web.multipart.MultipartFile
 import java.io.File
 import java.io.FileInputStream
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class ReportFileTests : FullApplicationTest() {
-    @Autowired lateinit var controller: ReportController
+    @Autowired
+    lateinit var controller: ReportController
 
-    @Autowired lateinit var orderController: OrderController
+    @Autowired
+    lateinit var orderController: OrderController
 
     @Test
     fun `create report files and fetch and delete`() {
@@ -71,7 +74,8 @@ class ReportFileTests : FullApplicationTest() {
                 reportId = createOrderResponse.reportId,
                 file = multipartFile,
                 documentType = DocumentType.LIITO_ORAVA_PISTEET,
-                description = "Test Description"
+                description = "Test Description",
+                id = UUID.randomUUID().toString()
             )
 
         val errors = response.body
@@ -100,7 +104,8 @@ class ReportFileTests : FullApplicationTest() {
                         "TEST FILE CONTENT".toByteArray()
                     ),
                 documentType = DocumentType.REPORT,
-                description = "Test Description"
+                description = "Test Description",
+                id = UUID.randomUUID().toString()
             )
 
         val errors = response.body
@@ -118,7 +123,8 @@ class ReportFileTests : FullApplicationTest() {
                     "MORE INFORMATION".toByteArray()
                 ),
             documentType = DocumentType.OTHER,
-            description = "Test Description"
+            description = "Test Description",
+            id = UUID.randomUUID().toString()
         )
 
         val reportFileResponse = controller.getReportFiles(adminUser, createOrderResponse.reportId)

--- a/service/src/test/kotlin/fi/espoo/luontotieto/ReportTests.kt
+++ b/service/src/test/kotlin/fi/espoo/luontotieto/ReportTests.kt
@@ -153,7 +153,8 @@ class ReportTests : FullApplicationTest() {
                                 inStream
                             ),
                         description = null,
-                        documentType = DocumentType.MUUT_HUOMIOITAVAT_LAJIT_ALUEET
+                        documentType = DocumentType.MUUT_HUOMIOITAVAT_LAJIT_ALUEET,
+                        id = UUID.randomUUID().toString()
                     ).statusCode.value(),
                     201
                 )
@@ -174,7 +175,8 @@ class ReportTests : FullApplicationTest() {
                                 inStream
                             ),
                         description = null,
-                        documentType = DocumentType.MUUT_HUOMIOITAVAT_LAJIT_VIIVAT
+                        documentType = DocumentType.MUUT_HUOMIOITAVAT_LAJIT_VIIVAT,
+                        id = UUID.randomUUID().toString()
                     ).statusCode.value(),
                     201
                 )
@@ -195,7 +197,8 @@ class ReportTests : FullApplicationTest() {
                                 inStream
                             ),
                         description = null,
-                        documentType = DocumentType.MUUT_HUOMIOITAVAT_LAJIT_PISTEET
+                        documentType = DocumentType.MUUT_HUOMIOITAVAT_LAJIT_PISTEET,
+                        id = UUID.randomUUID().toString()
                     ).statusCode.value(),
                     201
                 )
@@ -214,7 +217,8 @@ class ReportTests : FullApplicationTest() {
                             inStream
                         ),
                     description = "Alueelta löytyi ilves, torakka, jänis ja perhonen.",
-                    documentType = DocumentType.ALUERAJAUS_LUONTOSELVITYS
+                    documentType = DocumentType.ALUERAJAUS_LUONTOSELVITYS,
+                    id = UUID.randomUUID().toString()
                 ).statusCode.value(),
                 201
             )
@@ -232,7 +236,8 @@ class ReportTests : FullApplicationTest() {
                         "LUONTOSELVITYSRAPORTTI".toByteArray()
                     ),
                 description = null,
-                documentType = DocumentType.REPORT
+                documentType = DocumentType.REPORT,
+                id = UUID.randomUUID().toString()
             ).statusCode.value(),
             201
         )
@@ -356,7 +361,8 @@ class ReportTests : FullApplicationTest() {
                             "This is a text file".toByteArray()
                         ),
                     description = null,
-                    documentType = documentType
+                    documentType = documentType,
+                    id = UUID.randomUUID().toString()
                 )
             }
         }

--- a/service/src/test/kotlin/fi/espoo/luontotieto/TestHelpers.kt
+++ b/service/src/test/kotlin/fi/espoo/luontotieto/TestHelpers.kt
@@ -73,6 +73,7 @@ fun createLiitoOravaPisteetReportFile(
         reportId = reportId,
         file = multipartFile,
         documentType = DocumentType.LIITO_ORAVA_PISTEET,
-        description = "Test Description"
+        description = "Test Description",
+        id = UUID.randomUUID().toString()
     )
 }


### PR DESCRIPTION
Fixes file save errors for orders and reports
After this fix:
- Saving will try to save all files
- Possible errors for each file should be shown accordingly
- The frontend should correctly hold the failed file in memory 
- Other files should be saving and showing correctly and in correct order
- Fixed a bug where file title was showing boolean value