### PR TITLE
Add stricter limit zone for specific endpoints

### DIFF
--- a/frontend/nginx/etc/nginx/conf.d/default.conf.template
+++ b/frontend/nginx/etc/nginx/conf.d/default.conf.template
@@ -77,8 +77,21 @@ map $limit $limit_key {
 # limit_req_zone with a higher limit, as $binary_remote_addr is always defined.
 # The more restrictive limit is applied, so even though all clients will match
 # the second limit_req_zone, the first will be applied to non-whitelisted clients.
+
+# Normal configuration allows up to:
+# - 10 requests per second (rate=10r/s)
+# - Burst of 20 additional requests (burst=20) without delay
 limit_req_zone $limit_key zone=req_zone:10m rate=10r/s;
+
+# Whitelisted configuration allows up to:
+# - 100 requests per second (rate=100r/s)
+# - Burst of 50 additional requests (burst=50) without delay
 limit_req_zone $binary_remote_addr zone=req_zone_wl:1m rate=100r/s;
+
+# Explicitly define limit request for specific endpoints
+# Limits requests to 2 requests per second.
+limit_req_zone $binary_remote_addr zone=limit_zone:1m rate=2r/s;
+
 
 # Logging
 
@@ -186,6 +199,7 @@ server {
 
   limit_req         zone=req_zone burst=20 nodelay;
   limit_req         zone=req_zone_wl burst=50 nodelay;
+
   limit_req_status  429;
 
   location /health {
@@ -197,6 +211,27 @@ server {
   location /api {
     include     proxy_params;
     proxy_pass  $apiGatewayURL;
+  }
+
+  # Post orders route
+  location = /api/orders {
+    include     proxy_params;
+    proxy_pass  $apiGatewayURL;
+    limit_req zone=limit_zone;
+  }
+
+  # Update report route
+  location ~ ^/api/reports/[0-9a-zA-Z-]+$ {
+    include     proxy_params;
+    proxy_pass  $apiGatewayURL;
+    limit_req zone=limit_zone;
+  }
+
+  # Approve report route
+  location ~ ^/api/reports/[0-9a-zA-Z-]+/approve$ {
+    include     proxy_params;
+    proxy_pass  $apiGatewayURL;
+    limit_req zone=limit_zone;
   }
 
   location / {


### PR DESCRIPTION
Post orders, put report and approve report send emails as side effect, add more specific rate limit for these endpoints
to block the possibility of programmatically generating a big amount of spam emails.