### PR TITLE
fix: file description ux improvements

### DIFF
--- a/frontend/src/shared/form/File/ExistingFile.tsx
+++ b/frontend/src/shared/form/File/ExistingFile.tsx
@@ -23,10 +23,11 @@ import {
 import InfoModal from 'shared/modals/InfoModal'
 import { I, Label } from 'shared/typography'
 
+import { TextArea } from '../TextArea'
+
 import FileDownloadButton from './FileDownloadButton'
 import { FileTitle } from './FileTitle'
 import useDownloadFile from './useDownloadFile'
-import { TextArea } from '../TextArea'
 
 interface Props {
   data:

--- a/frontend/src/shared/form/File/ExistingFile.tsx
+++ b/frontend/src/shared/form/File/ExistingFile.tsx
@@ -95,10 +95,7 @@ export const ExistingFile = React.memo(function ExistingFile({
           <LabeledInput $cols={5}>
             {showTitle && <VerticalGap $size="L" />}
             <Label>Lisätiedot tarvittaessa</Label>
-            <TextArea
-              value={props.data.file.description}
-              readonly={props.data.readonly}
-            />
+            <TextArea value={props.data.file.description} readonly={true} />
           </LabeledInput>
         )}
       </FlexRowWithGaps>

--- a/frontend/src/shared/form/File/ExistingFile.tsx
+++ b/frontend/src/shared/form/File/ExistingFile.tsx
@@ -68,6 +68,12 @@ export const ExistingFile = React.memo(function ExistingFile({
     }
   }
 
+  const showDescription =
+    props.data.documentType ===
+      ReportFileDocumentType.ALUERAJAUS_LUONTOSELVITYS ||
+    props.data.documentType === ReportFileDocumentType.OTHER ||
+    props.data.documentType === OrderFileDocumentType.ORDER_INFO
+
   return (
     <FlexColWithGaps>
       <FlexRowWithGaps>
@@ -84,14 +90,16 @@ export const ExistingFile = React.memo(function ExistingFile({
             readonly={props.data.readonly}
           />
         </LabeledInput>
-        <LabeledInput $cols={5}>
-          {showTitle && <VerticalGap $size="L" />}
-          <Label>Lisätiedot tarvittaessa</Label>
-          <TextArea
-            value={props.data.file.description}
-            readonly={props.data.readonly}
-          />
-        </LabeledInput>
+        {showDescription && (
+          <LabeledInput $cols={5}>
+            {showTitle && <VerticalGap $size="L" />}
+            <Label>Lisätiedot tarvittaessa</Label>
+            <TextArea
+              value={props.data.file.description}
+              readonly={props.data.readonly}
+            />
+          </LabeledInput>
+        )}
       </FlexRowWithGaps>
       <FlexRowWithGaps>
         <I>{`Lisätty ${updatedStr}`}</I>

--- a/frontend/src/shared/form/TextArea.tsx
+++ b/frontend/src/shared/form/TextArea.tsx
@@ -175,7 +175,7 @@ const StyledTextArea = styled(TextareaAutosize)<{
     }
   }
 
-   &:read-only {
+  &:read-only {
     border-bottom-style: dashed;
     color: ${colors.grayscale.g70};
     background: none;


### PR DESCRIPTION
- Hide file description from the same fields during edit that are hidden in create mode
- Make file description field readonly for existing files (since we dont support updating the description only on API-level)
