### PR TITLE
Add aluetyyppi lisaantymis tai levahdyspaikka

### DIFF
--- a/service/src/main/kotlin/fi/espoo/luontotieto/config/FlywayConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/luontotieto/config/FlywayConfig.kt
@@ -18,7 +18,11 @@ class PaikkatietoFlywayConfig {
     @PostConstruct
     fun migrateFlyway() {
         val dataSource = dataSource ?: return
-        val config = Flyway.configure().dataSource(dataSource).locations("db/paikkatieto/migration")
+        val config =
+            Flyway.configure()
+                .dataSource(dataSource)
+                .locations("db/paikkatieto/migration")
+                .validateMigrationNaming(true)
 
         val flyway = Flyway(config)
         flyway.migrate()
@@ -32,7 +36,11 @@ class LuontotietoFlywayConfig {
     @PostConstruct
     fun migrateFlyway() {
         val dataSource = dataSource ?: return
-        val config = Flyway.configure().dataSource(dataSource).locations("db/luontotieto/migration")
+        val config =
+            Flyway.configure()
+                .dataSource(dataSource)
+                .locations("db/luontotieto/migration")
+                .validateMigrationNaming(true)
 
         val flyway = Flyway(config)
         flyway.migrate()

--- a/service/src/main/resources/db/paikkatieto/migration/V029_add_new_aluetyyppi_lisaantymis_tai_levahdyspaikka.sql
+++ b/service/src/main/resources/db/paikkatieto/migration/V029_add_new_aluetyyppi_lisaantymis_tai_levahdyspaikka.sql
@@ -1,1 +1,0 @@
-ALTER TYPE liito_orava_aluetyyppi ADD VALUE IF NOT EXISTS 'Lisääntymis- tai levähdyspaikka';

--- a/service/src/main/resources/db/paikkatieto/migration/V031__add_new_aluetyyppi_lisaantymis_tai_levahdyspaikka.sql
+++ b/service/src/main/resources/db/paikkatieto/migration/V031__add_new_aluetyyppi_lisaantymis_tai_levahdyspaikka.sql
@@ -1,0 +1,1 @@
+ALTER TYPE liito_orava_aluetyyppi ADD VALUE IF NOT EXISTS 'Lisääntymis- tai levähdyspaikka';


### PR DESCRIPTION
This was all already done earlier but due to missing underscore in the name it did not get picked up by Flyway. File is now renamed from 29 to 31 so that it will be run without issues even though number 30 has already run. Migration name validation is also switched on to avoid silent failures in the future. 