### PR TITLE
CI: build images in GHCR, push results to ECR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ on:
 
 env:
   AWS_REGION: eu-north-1
-  ECR_REGISTRY: 767398123997.dkr.ecr.eu-north-1.amazonaws.com
-  DOCKER_PULL: "${{ github.ref == 'refs/heads/master' && 'true' || 'false' }}"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +18,7 @@ concurrency:
 permissions:
   id-token: write
   contents: read
+  packages: write
 
 jobs:
   lint-shell:
@@ -68,18 +67,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Build image
-        uses: espoon-voltti/voltti-actions/docker-build-push@master
-        id: build
+      - name: Setup Docker building
+        id: setup
+        uses: espoon-voltti/voltti-actions/docker-setup@master
         with:
-          path: ${{ matrix.path }}
-          pull: ${{ env.DOCKER_PULL }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          registry: ${{ env.ECR_REGISTRY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS: false
+
+      - name: Build image
+        uses: espoon-voltti/voltti-actions/docker-build-registry@master
+        id: build
+        with:
+          registry: ghcr.io/espoon-voltti
           name: ${{ matrix.name }}
+          path: ${{ matrix.path }}
           build-args: |
             CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             build=${{ github.run_number }}
@@ -87,18 +90,14 @@ jobs:
 
       - name: Run tests
         if: ${{ matrix.test == 'true' }}
-        uses: espoon-voltti/voltti-actions/docker-build-push@master
+        uses: espoon-voltti/voltti-actions/docker-build-registry@master
         id: test
         with:
+          registry: ghcr.io/espoon-voltti
+          name: ${{ matrix.name }}-tests
           path: ${{ matrix.path }}
           push: false
           target: "test"
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          registry: ${{ env.ECR_REGISTRY }}
-          name: ${{ matrix.name }}-tests
           build-args: |
             CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             build=${{ github.run_number }}
@@ -116,23 +115,27 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Build builder
-        uses: espoon-voltti/voltti-actions/docker-build-push@master
-        id: builder
+      - name: Setup Docker building
+        id: setup
+        uses: espoon-voltti/voltti-actions/docker-setup@master
         with:
-          path: ${{ env.path }}
-          pull: ${{ env.DOCKER_PULL }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          registry: ${{ env.ECR_REGISTRY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS: false
+
+      - name: Build builder
+        uses: espoon-voltti/voltti-actions/docker-build-registry@master
+        id: builder
+        with:
+          registry: ghcr.io/espoon-voltti
           name: ${{ env.name }}-${{ env.builder }}
+          path: ${{ env.path }}
+          target: ${{ env.builder }}
           build-args: |
             CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.sha }}
-          target: ${{ env.builder }}
     outputs:
       builder_image: ${{ steps.builder.outputs.image }}
       builder_image_name: ${{ steps.builder.outputs.image_name }}
@@ -145,18 +148,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
         with:
-          aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-duration-seconds: 1200
-
-      - name: Login to Amazon ECR
-        id: ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          mask-password: 'true'
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load OWASP cache
         uses: espoon-voltti/voltti-actions/owasp-cache-get@master
@@ -189,18 +186,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Configure AWS credentials
+      - name: Login to GitHub Container Registry
         if: ${{ (github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]') && !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: docker/login-action@v4
         with:
-          aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-duration-seconds: 1200
-
-      - name: Login to Amazon ECR
-        if: ${{ (github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]') && !github.event.pull_request.head.repo.fork }}
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull images
         if: ${{ (github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]') && !github.event.pull_request.head.repo.fork }}
@@ -248,18 +240,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Configure AWS credentials
+      - name: Login to GitHub Container Registry
         if: ${{ (github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]') && !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: docker/login-action@v4
         with:
-          aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-duration-seconds: 1200
-
-      - name: Login to Amazon ECR
-        if: ${{ (github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]') && !github.event.pull_request.head.repo.fork }}
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull images
         if: ${{ (github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]') && !github.event.pull_request.head.repo.fork }}
@@ -295,11 +282,54 @@ jobs:
             compose/tests-all.log
           retention-days: 2
 
+  ecr-push:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    needs:
+      - dockerize
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-duration-seconds: 1200
+          mask-aws-account-id: false
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'true'
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Copy images from GHCR to ECR
+        env:
+          SHA: "${{ github.event.pull_request.head.sha || github.sha }}"
+          ECR: "${{ steps.ecr.outputs.registry }}"
+        run: |
+          set -euo pipefail
+          for image in service frontend api-gateway geoserver; do
+            src="ghcr.io/espoon-voltti/luontotieto/${image}:${SHA}"
+            dst="${ECR}/luontotieto/${image}:${SHA}"
+            echo "Copying ${src} -> ${dst}"
+            docker buildx imagetools create --prefer-index=false --tag "${dst}" "${src}"
+          done
+
   deploy:
     if: github.event.pull_request.user.login != 'renovate[bot]'
     runs-on: ubuntu-latest
     needs:
-      - dockerize
+      - ecr-push
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2023-2024 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+name: Cleanup GHCR
+
+on:
+  schedule:
+    # Daily 01:17 UTC: keep only the newest 100 versions per package.
+    - cron: '17 1 * * *'
+    # Sundays 02:17 UTC: keep only the newest version (safety net; deployable images live in ECR).
+    - cron: '17 2 * * 0'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Cleanup mode'
+        type: choice
+        options:
+          - keep-100
+          - keep-1
+        default: keep-100
+
+permissions:
+  packages: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  keep-recent:
+    if: ${{ github.event.schedule == '17 1 * * *' || github.event.inputs.mode == 'keep-100' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - luontotieto/service
+          - luontotieto/service-builder
+          - luontotieto/frontend
+          - luontotieto/frontend-tests
+          - luontotieto/api-gateway
+          - luontotieto/api-gateway-tests
+          - luontotieto/geoserver
+    steps:
+      - name: Delete untagged versions of ${{ matrix.package }}
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: espoon-voltti
+          package-name: ${{ matrix.package }}
+          package-type: container
+          delete-only-untagged-versions: 'true'
+
+      - name: Keep newest 100 versions of ${{ matrix.package }}
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: espoon-voltti
+          package-name: ${{ matrix.package }}
+          package-type: container
+          min-versions-to-keep: 100
+
+  keep-one:
+    if: ${{ github.event.schedule == '17 2 * * 0' || github.event.inputs.mode == 'keep-1' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - luontotieto/service
+          - luontotieto/service-builder
+          - luontotieto/frontend
+          - luontotieto/frontend-tests
+          - luontotieto/api-gateway
+          - luontotieto/api-gateway-tests
+          - luontotieto/geoserver
+    steps:
+      - name: Delete untagged versions of ${{ matrix.package }}
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: espoon-voltti
+          package-name: ${{ matrix.package }}
+          package-type: container
+          delete-only-untagged-versions: 'true'
+
+      - name: Keep only the newest version of ${{ matrix.package }}
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: espoon-voltti
+          package-name: ${{ matrix.package }}
+          package-type: container
+          min-versions-to-keep: 1

--- a/compose/docker-compose.e2e-test.yml
+++ b/compose/docker-compose.e2e-test.yml
@@ -6,7 +6,7 @@ version: '3.5'
 
 services:
   frontend:
-    image: 767398123997.dkr.ecr.eu-north-1.amazonaws.com/luontotieto/frontend:${TAG:-master}
+    image: ghcr.io/espoon-voltti/luontotieto/frontend:${TAG:-master}
     build:
       context: ../frontend/
     ports:
@@ -19,7 +19,7 @@ services:
       - api-gateway
 
   api-gateway:
-    image: 767398123997.dkr.ecr.eu-north-1.amazonaws.com/luontotieto/api-gateway:${TAG:-master}
+    image: ghcr.io/espoon-voltti/luontotieto/api-gateway:${TAG:-master}
     build:
       context: ../api-gateway/
     ports:
@@ -40,7 +40,7 @@ services:
       - redis
 
   service-e2e-tests:
-    image: 767398123997.dkr.ecr.eu-north-1.amazonaws.com/luontotieto/service-builder:${TAG:-master}
+    image: ghcr.io/espoon-voltti/luontotieto/service-builder:${TAG:-master}
     build:
       context: ../service/
       target: builder

--- a/compose/docker-compose.e2e.yml
+++ b/compose/docker-compose.e2e.yml
@@ -6,7 +6,7 @@ version: '3.5'
 
 services:
   frontend:
-    image: 767398123997.dkr.ecr.eu-north-1.amazonaws.com/luontotieto/frontend:${TAG:-master}
+    image: ghcr.io/espoon-voltti/luontotieto/frontend:${TAG:-master}
     build:
       context: ../frontend/
     read_only: true
@@ -20,7 +20,7 @@ services:
       HTTP_SCHEME: http
 
   service:
-    image: 767398123997.dkr.ecr.eu-north-1.amazonaws.com/luontotieto/service:${TAG:-master}
+    image: ghcr.io/espoon-voltti/luontotieto/service:${TAG:-master}
     build:
       context: ../service/
     read_only: true
@@ -38,7 +38,7 @@ services:
       APP_JWT_PUBLIC_KEYS_URL: classpath:local-development/jwks.json
 
   api-gateway:
-    image: 767398123997.dkr.ecr.eu-north-1.amazonaws.com/luontotieto/api-gateway:${TAG:-master}
+    image: ghcr.io/espoon-voltti/luontotieto/api-gateway:${TAG:-master}
     build:
       context: ../api-gateway/
     read_only: true

--- a/compose/docker-compose.test-service.yml
+++ b/compose/docker-compose.test-service.yml
@@ -6,7 +6,7 @@ version: '3.5'
 
 services:
   service-tests:
-    image: 767398123997.dkr.ecr.eu-north-1.amazonaws.com/luontotieto/service-builder:${TAG:-master}
+    image: ghcr.io/espoon-voltti/luontotieto/service-builder:${TAG:-master}
     build:
       context: ../service/
       target: builder


### PR DESCRIPTION
Build/test images now go to ghcr.io/espoon-voltti (docker-setup AWS:false + docker-build-registry) instead of pushing every build to ECR. A new ecr-push job copies the finished service/frontend/api-gateway/geoserver images from GHCR to ECR via `docker buildx imagetools create`; deploy retags within ECR as before. Compose test/e2e files pull images from GHCR. Adds cleanup-ghcr.yml (daily keep 100, weekly keep 1) to bound GHCR storage cost.