### PR TITLE
Fix shell-quote command injection (CVE-2026-9277)

### DIFF
--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -78,5 +78,8 @@
   "engines": {
     "node": ">= 20.11.0"
   },
-  "packageManager": "yarn@4.16.0"
+  "packageManager": "yarn@4.16.0",
+  "resolutions": {
+    "shell-quote": "1.8.4"
+  }
 }

--- a/api-gateway/yarn.lock
+++ b/api-gateway/yarn.lock
@@ -4426,10 +4426,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10/5473e354637c2bd698911224129c9a8961697486cff1fb221f234d71c153fc377674029b0223d1d3c953a68d451d79366abfe53d1a0b46ee1f28eb9ade928f4c
+"shell-quote@npm:1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10/a3e3796385f2cd5cf0b78207a4439f0c7395c0833fc75b2473084b5d298c109c5c0fa687fcd1c04e4b4484866e5bb8eaae7efae443b80fff71ea7e29baf11f0c
   languageName: node
   linkType: hard
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -94,5 +94,8 @@
       "postcss-preset-env": true
     }
   },
-  "packageManager": "yarn@4.16.0"
+  "packageManager": "yarn@4.16.0",
+  "resolutions": {
+    "shell-quote": "1.8.4"
+  }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6786,10 +6786,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10/5473e354637c2bd698911224129c9a8961697486cff1fb221f234d71c153fc377674029b0223d1d3c953a68d451d79366abfe53d1a0b46ee1f28eb9ade928f4c
+"shell-quote@npm:1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10/a3e3796385f2cd5cf0b78207a4439f0c7395c0833fc75b2473084b5d298c109c5c0fa687fcd1c04e4b4484866e5bb8eaae7efae443b80fff71ea7e29baf11f0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Forces `shell-quote` to `1.8.4` via yarn `resolutions` in `frontend` and `api-gateway`.

It is pulled in transitively (dev-only) by `concurrently@9.2.1`, which pins it to exactly `1.8.3`, so it cannot be bumped without an override.

Resolves GHSA-w7jw-789q-3m8p / CVE-2026-9277 (critical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)