### PR TITLE
ci: don't run ecr-push for Dependabot/Renovate PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,7 +283,7 @@ jobs:
           retention-days: 2
 
   ecr-push:
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ (github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]') && !github.event.pull_request.head.repo.fork }}
     needs:
       - dockerize
     runs-on: ubuntu-latest


### PR DESCRIPTION
Bots have no access to repository secrets, so AWS_ROLE is empty and the ecr-push job fails when configuring AWS credentials. Bot PRs should only build and test, never push images to ECR. Gate ecr-push on the actor to match the other deploy-related steps in this workflow.