### PR TITLE
ci(owasp): use only nightly NVD cache in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,6 +167,7 @@ jobs:
         shell: bash
         run: |
           docker run --rm \
+              -e CI=true \
               -e NVD_API_KEY=${{ secrets.NVD_API_KEY }} \
               -v $(pwd)/dependency-check-data:/root/.gradle/dependency-check-data \
               ${{ needs.service-builder.outputs.builder_image }} \

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -180,6 +180,10 @@ tasks {
 
     dependencyCheck {
         failBuildOnCVSS = 0.0f
+        // In CI, use only the prebuilt nightly NVD cache mounted by owasp-cache-get
+        // and never fetch updates at analyze time. Locally keep autoUpdate on so a
+        // dev run can populate/refresh its own database.
+        autoUpdate = System.getenv("CI") != "true"
         analyzers.apply {
             assemblyEnabled = false
             centralEnabled = false


### PR DESCRIPTION
Set dependencyCheck autoUpdate=false when CI=true so dependencyCheckAnalyze relies solely on the prebuilt nightly cache mounted by owasp-cache-get and performs no NVD/aux-feed downloads at analyze time. Pass CI=true into the owasp docker container so the gated value reaches Gradle inside it. Local runs (CI unset) keep autoUpdate on to populate/refresh their own database.