### PR TITLE
owasp boot bom CVE overrides

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -46,6 +46,17 @@ ktfmt { kotlinLangStyle() }
 
 ktlint { version.set(libs.versions.ktlint.asProvider().get()) }
 
+// cve fixes above the Spring Boot BOM; drop each once Boot manages a higher version
+extra["tomcat.version"] = "11.0.24" // 8 CVEs, worst CVE-2026-53434 (9.1)
+
+extra["netty.version"] = "4.2.16.Final" // 10 CVEs, worst CVE-2026-55851 (8.7)
+
+extra["httpcore5.version"] = "5.4.3" // CVE-2026-54399, -54428 (7.5)
+
+extra["log4j2.version"] = "2.25.5" // CVE-2026-49844 (6.3)
+
+extra["jackson-2-bom.version"] = libs.versions.jackson.get() // CVE-2026-54515 (5.3)
+
 dependencies {
     api(kotlin("stdlib"))
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -13,4 +13,9 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         <cve>CVE-2026-25477</cve>
         <cve>CVE-2026-21853</cve>
     </suppress>
+    <suppress until="2026-11-01Z">
+        <notes>Kotlin build tooling; 2.4.10 is the latest stable release.</notes>
+        <cpe>cpe:/a:jetbrains:kotlin</cpe>
+        <cve>CVE-2026-53914</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Spring Boot 4.1.0 is the newest release and still manages vulnerable tomcat, netty, httpcore5, log4j2 and jackson, so no Boot upgrade picks them up.

Overriding via the BOM version properties moves each artifact family together (netty alone is 14 modules; tomcat-embed-el has to match tomcat-embed-core). These are temporary — delete each line once Boot manages an equal or higher version.

Worst findings: CVE-2026-53434, -55276, -59083 and -59084 in tomcat, all CVSS 9.1 and reachable without authentication. httpcore5 carries every S3 and SES call, and Boot was pinning it below the version the AWS SDK itself requests.

CVE-2026-53914 (Kotlin) is suppressed rather than fixed: 2.4.10 is the latest stable release, and the flagged jars are build tooling that never ships.